### PR TITLE
Changed Project Issue link #485

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ routes
 
 ## 🐛 How to Report Bugs
 
-Please open a [new issue](https://github.com/hashirshoaeb/star_book/issues/new) including steps to reproduce the problem
+Please open a [new issue](https://github.com/Blocship/star_book/issues/new) including steps to reproduce the problem
 you're experiencing.
 
 Be sure to include as much information including screenshots, text output, and


### PR DESCRIPTION
This pull request addresses the following changes in the project's documentation:

Replaces the GitHub issues link in CONTRIBUTING.md from "https://github.com/hashirshoaeb/star_book/issues" to "https://github.com/Blocship/star_book/issues".
This change aligns the documentation with the correct GitHub repository and will help users and contributors navigate to the correct location for reporting issues and seeking help.

Closes Issues:
Closes https://github.com/Blocship/star_book/issues/485